### PR TITLE
fix/로그인 시 에러처리 수정

### DIFF
--- a/auth/passport.js
+++ b/auth/passport.js
@@ -14,11 +14,11 @@ passport.use(
       const user = await User.findOne({ where: { username } });
       console.log('user:', user);
       if (!user) {
-        return done(null, false, { message: 'Incorrect username.' });
+        return done(null, false, { message: '존재하지 않는 아이디입니다.' });
       }
       const isValid = await bcrypt.compare(password, user.password);
       if (!isValid) {
-        return done(null, false, { message: 'Incorrect password.' });
+        return done(null, false, { message: '비밀번호를 확인해주세요.' });
       }
       return done(null, user);
     } catch (error) {

--- a/mindayBack.js
+++ b/mindayBack.js
@@ -91,10 +91,11 @@ app.post('/api/join/check', async (req, res) => {
 app.post('/api/login', (req, res, next) => {
   passport.authenticate('local', (err, user, info) => {
     if (err) return next(err);
-    if (!user) return res.status(401).json(info.message);
+    if (!user)
+      return res.status(200).json({ success: false, message: info.message });
 
     const token = generateToken(user);
-    res.json({ token, id_user:user.id_user });
+    res.json({ success: true, token, id_user: user.id_user });
   })(req, res, next);
 });
 
@@ -151,10 +152,13 @@ app.post('/updatechecklist', authenticateToken, async (req, res) => {
   const { state } = req.body;
   Object.keys(state).forEach(async (key) => {
     try {
-      const res = await Askcheck.update({
-        content: state[key].content,
-        isdone: state[key].isdone,
-      },{ where: { type: key, id_askcheck: state[key].id_askcheck } });
+      const res = await Askcheck.update(
+        {
+          content: state[key].content,
+          isdone: state[key].isdone,
+        },
+        { where: { type: key, id_askcheck: state[key].id_askcheck } }
+      );
       console.log('Update success!');
     } catch (err) {
       console.error(err);
@@ -268,8 +272,7 @@ app.get('/mind', authenticateToken, async (req, res) => {
   }
 });
 
-
-app.get('/comment', authenticateToken,async (req, res) => {
+app.get('/comment', authenticateToken, async (req, res) => {
   try {
     const comment = await Comment.findAll();
     res.json(comment);
@@ -288,13 +291,13 @@ app.get('/postuser', authenticateToken, async (req, res) => {
 });
 
 app.post('/new', authenticateToken, async (req, res) => {
-  const  { id_user, title, body, anonymity } = req.body.data;
+  const { id_user, title, body, anonymity } = req.body.data;
   try {
     const post = await Post.create({
       id_user: id_user,
       title: title,
       body: body,
-      anonymity: anonymity
+      anonymity: anonymity,
     });
     res.json(post);
   } catch (error) {
@@ -309,7 +312,7 @@ app.post('/comment', authenticateToken, async (req, res) => {
       id_comment: id_comment,
       body: body,
       id_user: id_user,
-      id_post: id_post
+      id_post: id_post,
     });
     res.json(comment);
   } catch (error) {
@@ -321,21 +324,21 @@ app.post('/edit', authenticateToken, async (req, res) => {
   const { title, body, id_post } = req.body.data;
   try {
     const edit = await Post.update(
-      {title: title, body: body},
-      {where: {id_post: id_post}});
+      { title: title, body: body },
+      { where: { id_post: id_post } }
+    );
     res.json(edit);
   } catch (error) {
     console.error('Query Failed:', error);
   }
 });
 
-app.post('/delete',  authenticateToken, async (req, res) => {
+app.post('/delete', authenticateToken, async (req, res) => {
   const { id_post, id_comment } = req.body.data;
   try {
-    const comment = await Comment.destroy(
-      {where: {id_post: id_post,
-        id_comment: id_comment
-      }});
+    const comment = await Comment.destroy({
+      where: { id_post: id_post, id_comment: id_comment },
+    });
     res.json(comment);
   } catch (error) {
     console.error('Query Failed:', error);


### PR DESCRIPTION
close #21

로그인 시 잘못된 아이디/비밀번호를 입력했을 때 401 에러와 함께 alert창을 띄우는 것을 수정하였습니다.

status 코드를 200으로 보내고 프론트에서 message값을 통해 모달에 전달하였습니다.
로그인 실패시 개발자 도구에서 콘솔 에러가 안 나게 하였습니다.