### PR TITLE
feat: Add Emotion model and Handle GET request for Emotion data

### DIFF
--- a/mindayBack.js
+++ b/mindayBack.js
@@ -17,7 +17,8 @@ const {
   Diarylist,
   Diary,
   Comment,
-  Contents
+  Contents,
+  EmotionList
 } = require('./models');
 const { passport, generateToken } = require('./auth/passport');
 
@@ -391,6 +392,16 @@ app.post('/updateuser', authenticateToken, async (req, res) => {
     res.status(200).json({ message: '정보가 성공적으로 업데이트되었습니다.' });
   } catch (error) {
     res.status(502).json({ error: '정보 변경에 오류가 발생했습니다.' });
+  }
+});
+
+//////////////////////////// emotionlist feat ////////////////////////////////
+app.get('/emotionicons', authenticateToken, async (req, res) => {
+  try {
+    const emotionicons = await EmotionList.findAll();
+    res.json(emotionicons);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch books' });
   }
 });
 

--- a/models/emotionlist.js
+++ b/models/emotionlist.js
@@ -1,0 +1,17 @@
+const { Model, DataTypes } = require('sequelize');
+
+class EmotionList extends Model {
+  static init(sequelize) {
+    return super.init({
+      id_emotionlist: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+      emotionname: { type: DataTypes.STRING, allowNull: false, unique:true },
+      emotionimg: { type: DataTypes.STRING, allowNull: false, unique:true },
+    }, {
+      sequelize,
+      tableName: 'emotionlist',
+      timestamps: false
+    });
+  }
+}
+
+module.exports = EmotionList;

--- a/models/index.js
+++ b/models/index.js
@@ -8,6 +8,7 @@ const Diary = require('./diary');
 const Diarylist = require('./diarylist');
 const Comment = require('./comment');
 const Contents = require('./contents');
+const EmotionList = require('./emotionlist');
 
 const env = process.env.NODE_ENV || 'development';
 const config = require('../config/config')[env];
@@ -24,7 +25,8 @@ const db = {
   Comment: Comment.init(sequelize),
   Diary: Diary.init(sequelize),
   Diarylist: Diarylist.init(sequelize),
-  Contents: Contents.init(sequelize)
+  Contents: Contents.init(sequelize),
+  EmotionList: EmotionList.init(sequelize)
 };
 
 


### PR DESCRIPTION
- emotion 데이터 있는 모델 생성했습니다
(insert문은 따로 slack으로 보내드리겠습니다.)
- 사용자의 get 요청에 응답하는 코드 구현했습니다.